### PR TITLE
feat: added new workflow to prune old images

### DIFF
--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -1,8 +1,8 @@
 name: Prune GHCR
 
 on:
-  push:
-  pull_request:
+  schedule:
+    - cron: '0 0 * * *' # Runs workflow at '(minute) (hour) (day of the month) (month) (day of the week)'
 
 permissions:
   contents: write
@@ -27,14 +27,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           organization: caas-team
           container: sparrow # Package name
-          dry-run: true # Dry-run first, then change to `false`
+          dry-run: true # Dry-run first, then change to `false` or remove
           keep-younger-than: 7 # days
           keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |
             ^commit-
             SNAPSHOT-.*$
-            actions$
 
       - name: Prune Charts
         uses: vlaurin/action-ghcr-prune@v0.5.0
@@ -42,8 +41,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           organization: caas-team
           container: charts/sparrow # Package name
-          dry-run: true # Dry-run first, then change to `false`
-          #keep-younger-than: 7 # days
+          dry-run: true # Dry-run first, then change to `false` or remove
+          keep-younger-than: 7 # days
           keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |


### PR DESCRIPTION
## Motivation

<!-- Explain what motivated you to do these changes -->
Relates to https://github.com/caas-team/sparrow/issues/80
## Changes
Added a new workflow to prune old images of packages sparrow and charts/sparrow.
The workflow is configured to prune all images older than 7 days that start with 'commit-' or end in 'SNAPSHOT-...' for the sparrow package. 
For the charts/sparrow package it will prune all images older than 7 days that end in 'commit-...'.
It will run daily at midnight (could be changed if wanted) and keeps the last two versions for rollback purposes.
It is still configured to dry-run just to be sure. This should be changed once we're sure nothings going to break.
<!-- Explain what you've changed -->

For additional information look at the commits.

## Tests done
I've tested the workflow in dry-run in a fork I made and it worked accordingly.
No stable version or version under 7 days was marked for pruning.
<!-- Explain what tests you've done and if your tests worked -->

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->